### PR TITLE
Feature/unsync id3v2

### DIFF
--- a/flac2mp3.pl
+++ b/flac2mp3.pl
@@ -193,6 +193,10 @@ foreach my $cmd ( $flaccmd, $lamecmd ) {
     $Options{info} && msg("Using $cmd from: $cmdpath");
 }
 
+# Turn off unsyncing, due to broken implementation in
+# some software (such as Logitech Media Server)
+MP3::Tag->config(id3v23_unsync => 0);
+
 # Convert directories to absolute paths
 $source_root  = File::Spec->rel2abs($source_root);
 $target_root = File::Spec->rel2abs($target_root);


### PR DESCRIPTION
Found that some software still has problems with unsynchronized frames. Therefore turning off id3v2.3 unsyncing - again. (This time due to inability of Logitech Media Sever to cope with it.)
