### PR TITLE
Feature/windows lame flac paths

### DIFF
--- a/flac2mp3.pl
+++ b/flac2mp3.pl
@@ -47,8 +47,18 @@ use Digest::MD5;
 #      c:/windows/system32/flac.exe
 #    or
 #      c:\\windows\\system32\\flac.exe
-my $flaccmd = 'flac';
-my $lamecmd = 'lame';
+
+my ($flaccmd, $lamecmd);
+if ($^O eq 'MSWin32' or $^O eq 'MSWin64') {
+	# This is an example of typical Windows filepaths. 
+	# Change them if necessary:
+	$flaccmd = q|C:\Program Files (x86)\FLAC\flac.exe|;
+	$lamecmd = q|C:\Program Files\LAME\lame.exe|;
+}
+else {
+	$flaccmd = 'flac';
+	$lamecmd = 'lame';
+}
 
 # Modify lame options if required
 my @lameargs = qw (


### PR DESCRIPTION
lame and flac paths on windows
As a service to windows users, the paths to typical locations of lame and flac are provided. These will work for most (intended for people who haven't included these paths into the environment variables).
