### PR TITLE
Feature/option delete

### DIFF
--- a/flac2mp3.pl
+++ b/flac2mp3.pl
@@ -162,7 +162,7 @@ my %Options = (
 GetOptions(
     \%Options,     "quiet!",         "tagdiff", "debug!",  "tagsonly!", "force!",
     "usage",       "help",           "version", "pretend", "skipfile!", "skipfilename=s",
-    "processes=i", "tagseparator=s", "lameargs=s", "copyfiles"
+    "processes=i", "tagseparator=s", "lameargs=s", "copyfiles", "delete"
 );
 
 # info flag is the inverse of --quiet
@@ -229,6 +229,10 @@ my @flac_files = sort keys { %flac_mp3_files };
 	
 my $file_count = scalar @flac_files;
 msg_info( "Found $file_count flac file" . ( $file_count > 1 ? 's'  : '' . "\n" ) );
+
+# If allowed, delete surplus files and folders from target directory, keeping 
+# it in perfect sync with (i.e. a mirror of) the source directory.  
+delete_excess_files_from_dest($source_root, $target_root) if ( $Options{delete} ) ;
 
 
 # use parallel processing to launch multiple transcoding processes
@@ -300,6 +304,64 @@ sub get_md5_of_non_flac_file {
     close FILE;
     return $md5_code;
 };
+
+sub delete_excess_files_from_dest {
+	my ($source_root, $target_root) = @_;
+	
+	# Generate (source => target) hashes for the files found using 
+	# each of the following combinations of root dirs and file suffixes 
+	my %existing_target_mp3_files = get_all_paths('name', '.mp3', $target_root, $target_root, '.mp3');
+	my %existing_source_mp3_files = get_all_paths('name', '.mp3', $source_root, $target_root, '.mp3');
+	my %non_flac_files = get_all_paths('not_name', '.flac', $source_root, $target_root, '');
+	my %existing_target_non_mp3_files = get_all_paths('not_name', '.mp3', $target_root, $target_root, '');
+	
+	# 1. calculate what files to expect in directory after finished transcoding and copying
+	my @expected_transcoded_mp3s = keys { reverse %flac_mp3_files }; # expected mp3 files in target from transcoded flac files
+	my @expected_copied_files = keys { reverse %non_flac_files }; # expected files in target copied from non-flac files in source
+	my @expected_files = uniq(@expected_transcoded_mp3s, @expected_copied_files); # Join the arrays and remove any duplicates 
+	
+	# 2. check what files are actually present
+	my @actual_mp3s = keys { reverse %existing_target_mp3_files }; # actual existing mp3 files in target
+	my @actual_non_mp3s = keys { reverse %existing_target_non_mp3_files }; # existing non-mp3 files in target
+	my @actual_files = (@actual_mp3s, @actual_non_mp3s); # Join the arrays (being mutually exclusive, there is no overlap) 
+	
+	# 3. determine which files to remove from target directory tree
+	my @files_to_remove = single_difference(\@expected_files, \@actual_files);
+	
+	# 4. determine which subdirectories to remove from target directory tree
+	my @expected_subdirs_in_target = get_all_dirs($source_root,$target_root);
+	my @actual_subdirs_in_target = get_all_dirs($target_root,$target_root);
+	my @dirs_to_remove = single_difference(\@expected_subdirs_in_target, \@actual_subdirs_in_target);
+	
+	# 5. carry out the deletions 
+	foreach my $file (@files_to_remove) {
+		$Options{pretend} || unlink $file or die "Unable to delete $file: $!";
+		msg_info($pretendString . "Deleted \"$file\"");
+	}
+	foreach my $dir (reverse sort @dirs_to_remove) {
+		$Options{pretend} || File::Path->remove_tree($dir) or die "Unable to delete directory $dir: $!";
+		msg_info($pretendString . "Deleted directory \"$dir\"");
+	}
+}
+
+# Return all unique elements of input array @_
+sub uniq { 
+	return sort keys %{{ map { $_ => 1 } @_ }} 
+};
+
+# Acccept two arrays @A and @B as argument, return elements in @B that aren't in @A.
+sub single_difference { 
+	my ($A, $B) = @_;
+
+	# build lookup table
+	my %seen = ();
+	my @bonly = ();
+	@seen{@$A} = (1) x @$A;
+	foreach my $item (@$B) {
+		push(@bonly, $item) unless $seen{$item};
+	}
+	return sort @bonly;
+}
 
 sub get_all_dirs {
 	my ($root, $new_root) = @_;
@@ -399,6 +461,7 @@ Usage: $0 [--pretend] [--quiet] [--debug] [--tagsonly] [--force] [--tagdiff] [--
                      same tag.
                      Default: "/"
     --copyfiles      Copy non-flac files to dest directories
+    --delete         Delete surplus files and directories in destination, keeping in sync with source dir
 EOT
     exit 0;
 }


### PR DESCRIPTION
add option --delete

This option works as the --delete option in "rsync": it deletes surplus files and directories in the destination, keeping in perfect sync with the source dir.
