### PR TITLE
Invoke showusage() when passing --help

### DIFF
--- a/flac2mp3.pl
+++ b/flac2mp3.pl
@@ -164,12 +164,12 @@ $| = 1;
 my ( $source_root, $target_root ) = @ARGV;
 
 showversion() if ( $Options{version} );
-showhelp()    if ( $Options{help} );
 showusage()
     if ( !defined $source_root
     or !defined $target_root
     or $Options{processes} < 1
-    or $Options{usage} );
+    or $Options{usage}
+    or $Options{help} );
 
 @lameargs = $Options{lameargs}
     if $Options{lameargs};


### PR DESCRIPTION
By invoking showusage() when passing --help, the user gets some helpful information.

Fixes https://github.com/robinbowes/flac2mp3/issues/33
