### PR TITLE
fixed a bug that would cause this to not work on OSX across network file

### DIFF
--- a/flac2mp3.pl
+++ b/flac2mp3.pl
@@ -698,6 +698,7 @@ sub transcode_file {
         # Convert the file (unless we're pretending}
         my $exit_value;
         if ( !$Options{pretend} ) {
+            unlink $tmpfilename;
             $exit_value = system($convert_command);
         }
         else {


### PR DESCRIPTION
shares.  Basically the perl temp file mechanism hangs onto open file
hooks and then lame, when forked in another system process, can't init the
file by the same name.  Just remove it before running lame.  Perl file
cleanup still works properly.
