### PR TITLE
Escape file names

### DIFF
--- a/flac2mp3.pl
+++ b/flac2mp3.pl
@@ -687,7 +687,7 @@ sub transcode_file {
 		$Options{info}
             && msg( $pretendString . "Transcoding    \"$source\"" );
 
-        my $convert_command = "\"$flaccmd\" @flacargs \"$source\"" . "| \"$lamecmd\" @lameargs - \"$tmpfilename\"";
+        my $convert_command = "\"$flaccmd\" @flacargs " . quotemeta($source) . "| \"$lamecmd\" @lameargs - " . quotemeta($tmpfilename);
 
         $Options{debug} && msg("transcode: $convert_command");
 


### PR DESCRIPTION
Various issues/PRs exist to quote "special" characters in file names.

This change should fix everything.
